### PR TITLE
config: map dev PG docker to 5440 port

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,6 +1,6 @@
 # Development
 
-DATABASE_URL="postgres://postgres:password@localhost:5432/dddforum"
+DATABASE_URL="postgres://postgres:password@localhost:5440/dddforum"
 POSTGRES_USER=postgres
 POSTGRES_DB=dddforum
 POSTGRES_PASSWORD=password

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - .env
     ports:
-      - 5432:5432
+      - 5440:5432


### PR DESCRIPTION
Map PostgreSQL dev container to 5440 to avoid interference with locally installed PostgreSQL instance.

To test:
- Stop docker-compose
- `cd backend`
- `npm run start:dev` - it will restart docker-compose, which also will remap the ports
- Stop the server
- `npm run test:e2e`